### PR TITLE
Prepare repository bundles for JRebel

### DIFF
--- a/org.eclipse.richbeans.annot/.project
+++ b/org.eclipse.richbeans.annot/.project
@@ -20,9 +20,21 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.zeroturnaround.eclipse.rebelXmlBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.zeroturnaround.eclipse.remoting.remotingBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.zeroturnaround.eclipse.jrebelNature</nature>
+		<nature>org.zeroturnaround.eclipse.remoting.remotingNature</nature>
 	</natures>
 </projectDescription>

--- a/org.eclipse.richbeans.annot/src/rebel-remote.xml
+++ b/org.eclipse.richbeans.annot/src/rebel-remote.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rebel-remote xmlns="http://www.zeroturnaround.com/rebel/remote">
+    <id>org_2Eeclipse_2Erichbeans_2Eannot</id>
+</rebel-remote>

--- a/org.eclipse.richbeans.annot/src/rebel.xml
+++ b/org.eclipse.richbeans.annot/src/rebel.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
+
+	<classpath>
+		<dir name="${rebel.workspace.path}_git/richbeans.git/org.eclipse.richbeans.annot/bin">
+		</dir>
+	</classpath>
+
+</application>

--- a/org.eclipse.richbeans.api/.project
+++ b/org.eclipse.richbeans.api/.project
@@ -20,9 +20,21 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.zeroturnaround.eclipse.rebelXmlBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.zeroturnaround.eclipse.remoting.remotingBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.zeroturnaround.eclipse.jrebelNature</nature>
+		<nature>org.zeroturnaround.eclipse.remoting.remotingNature</nature>
 	</natures>
 </projectDescription>

--- a/org.eclipse.richbeans.api/src/rebel-remote.xml
+++ b/org.eclipse.richbeans.api/src/rebel-remote.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rebel-remote xmlns="http://www.zeroturnaround.com/rebel/remote">
+    <id>org_2Eeclipse_2Erichbeans_2Eapi</id>
+</rebel-remote>

--- a/org.eclipse.richbeans.api/src/rebel.xml
+++ b/org.eclipse.richbeans.api/src/rebel.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
+
+	<classpath>
+		<dir name="${rebel.workspace.path}_git/richbeans.git/org.eclipse.richbeans.api/bin">
+		</dir>
+	</classpath>
+
+</application>

--- a/org.eclipse.richbeans.binding/.project
+++ b/org.eclipse.richbeans.binding/.project
@@ -25,9 +25,21 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.zeroturnaround.eclipse.rebelXmlBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.zeroturnaround.eclipse.remoting.remotingBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.zeroturnaround.eclipse.jrebelNature</nature>
+		<nature>org.zeroturnaround.eclipse.remoting.remotingNature</nature>
 	</natures>
 </projectDescription>

--- a/org.eclipse.richbeans.binding/src/rebel-remote.xml
+++ b/org.eclipse.richbeans.binding/src/rebel-remote.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rebel-remote xmlns="http://www.zeroturnaround.com/rebel/remote">
+    <id>org_2Eeclipse_2Erichbeans_2Ebinding</id>
+</rebel-remote>

--- a/org.eclipse.richbeans.binding/src/rebel.xml
+++ b/org.eclipse.richbeans.binding/src/rebel.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
+
+	<classpath>
+		<dir name="${rebel.workspace.path}_git/richbeans.git/org.eclipse.richbeans.binding/bin">
+		</dir>
+	</classpath>
+
+</application>

--- a/org.eclipse.richbeans.examples/.project
+++ b/org.eclipse.richbeans.examples/.project
@@ -20,9 +20,21 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.zeroturnaround.eclipse.rebelXmlBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.zeroturnaround.eclipse.remoting.remotingBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.zeroturnaround.eclipse.jrebelNature</nature>
+		<nature>org.zeroturnaround.eclipse.remoting.remotingNature</nature>
 	</natures>
 </projectDescription>

--- a/org.eclipse.richbeans.examples/src/rebel-remote.xml
+++ b/org.eclipse.richbeans.examples/src/rebel-remote.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rebel-remote xmlns="http://www.zeroturnaround.com/rebel/remote">
+    <id>org_2Eeclipse_2Erichbeans_2Eexamples</id>
+</rebel-remote>

--- a/org.eclipse.richbeans.examples/src/rebel.xml
+++ b/org.eclipse.richbeans.examples/src/rebel.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
+
+	<classpath>
+		<dir name="${rebel.workspace.path}_git/richbeans.git/org.eclipse.richbeans.examples/bin">
+		</dir>
+	</classpath>
+
+</application>

--- a/org.eclipse.richbeans.reflection/.project
+++ b/org.eclipse.richbeans.reflection/.project
@@ -25,9 +25,21 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.zeroturnaround.eclipse.rebelXmlBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.zeroturnaround.eclipse.remoting.remotingBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.zeroturnaround.eclipse.jrebelNature</nature>
+		<nature>org.zeroturnaround.eclipse.remoting.remotingNature</nature>
 	</natures>
 </projectDescription>

--- a/org.eclipse.richbeans.reflection/src/rebel-remote.xml
+++ b/org.eclipse.richbeans.reflection/src/rebel-remote.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rebel-remote xmlns="http://www.zeroturnaround.com/rebel/remote">
+    <id>org_2Eeclipse_2Erichbeans_2Ereflection</id>
+</rebel-remote>

--- a/org.eclipse.richbeans.reflection/src/rebel.xml
+++ b/org.eclipse.richbeans.reflection/src/rebel.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
+
+	<classpath>
+		<dir name="${rebel.workspace.path}_git/richbeans.git/org.eclipse.richbeans.reflection/bin">
+		</dir>
+	</classpath>
+
+</application>

--- a/org.eclipse.richbeans.widgets.file/.project
+++ b/org.eclipse.richbeans.widgets.file/.project
@@ -20,9 +20,21 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.zeroturnaround.eclipse.rebelXmlBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.zeroturnaround.eclipse.remoting.remotingBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.zeroturnaround.eclipse.jrebelNature</nature>
+		<nature>org.zeroturnaround.eclipse.remoting.remotingNature</nature>
 	</natures>
 </projectDescription>

--- a/org.eclipse.richbeans.widgets.file/src/rebel-remote.xml
+++ b/org.eclipse.richbeans.widgets.file/src/rebel-remote.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rebel-remote xmlns="http://www.zeroturnaround.com/rebel/remote">
+    <id>org_2Eeclipse_2Erichbeans_2Ewidgets_2Efile</id>
+</rebel-remote>

--- a/org.eclipse.richbeans.widgets.file/src/rebel.xml
+++ b/org.eclipse.richbeans.widgets.file/src/rebel.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
+
+	<classpath>
+		<dir name="${rebel.workspace.path}_git/richbeans.git/org.eclipse.richbeans.widgets.file/bin">
+		</dir>
+	</classpath>
+
+</application>

--- a/org.eclipse.richbeans.widgets/.project
+++ b/org.eclipse.richbeans.widgets/.project
@@ -20,9 +20,21 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.zeroturnaround.eclipse.rebelXmlBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.zeroturnaround.eclipse.remoting.remotingBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.zeroturnaround.eclipse.jrebelNature</nature>
+		<nature>org.zeroturnaround.eclipse.remoting.remotingNature</nature>
 	</natures>
 </projectDescription>

--- a/org.eclipse.richbeans.widgets/src/rebel-remote.xml
+++ b/org.eclipse.richbeans.widgets/src/rebel-remote.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rebel-remote xmlns="http://www.zeroturnaround.com/rebel/remote">
+    <id>org_2Eeclipse_2Erichbeans_2Ewidgets</id>
+</rebel-remote>

--- a/org.eclipse.richbeans.widgets/src/rebel.xml
+++ b/org.eclipse.richbeans.widgets/src/rebel.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
+
+	<classpath>
+		<dir name="${rebel.workspace.path}_git/richbeans.git/org.eclipse.richbeans.widgets/bin">
+		</dir>
+	</classpath>
+
+</application>

--- a/org.eclipse.richbeans.xml/.project
+++ b/org.eclipse.richbeans.xml/.project
@@ -20,9 +20,21 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.zeroturnaround.eclipse.rebelXmlBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.zeroturnaround.eclipse.remoting.remotingBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.zeroturnaround.eclipse.jrebelNature</nature>
+		<nature>org.zeroturnaround.eclipse.remoting.remotingNature</nature>
 	</natures>
 </projectDescription>

--- a/org.eclipse.richbeans.xml/src/rebel-remote.xml
+++ b/org.eclipse.richbeans.xml/src/rebel-remote.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rebel-remote xmlns="http://www.zeroturnaround.com/rebel/remote">
+    <id>org_2Eeclipse_2Erichbeans_2Exml</id>
+</rebel-remote>

--- a/org.eclipse.richbeans.xml/src/rebel.xml
+++ b/org.eclipse.richbeans.xml/src/rebel.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
+
+	<classpath>
+		<dir name="${rebel.workspace.path}_git/richbeans.git/org.eclipse.richbeans.xml/bin">
+		</dir>
+	</classpath>
+
+</application>


### PR DESCRIPTION
Ref: https://github.com/eclipse/richbeans/issues/102

In order for a bundle to be accessible to JRebel for hot code
replacement in both local and remote mode two xml files must be added
along with some extra natures in the project file. The files are
generated automatically by the JRebel setup menus and are fixed for a
standalone application. The paths in the xml files have been 
parameterised so that they are applicable to anyone's machine.
