### PR TITLE
Update JRebel config

### DIFF
--- a/org.eclipse.richbeans.annot/src/rebel.xml
+++ b/org.eclipse.richbeans.annot/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/richbeans.git/org.eclipse.richbeans.annot/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/richbeans.git/org.eclipse.richbeans.annot/bin">
 		</dir>
 	</classpath>
 

--- a/org.eclipse.richbeans.api/src/rebel.xml
+++ b/org.eclipse.richbeans.api/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/richbeans.git/org.eclipse.richbeans.api/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/richbeans.git/org.eclipse.richbeans.api/bin">
 		</dir>
 	</classpath>
 

--- a/org.eclipse.richbeans.binding/src/rebel.xml
+++ b/org.eclipse.richbeans.binding/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/richbeans.git/org.eclipse.richbeans.binding/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/richbeans.git/org.eclipse.richbeans.binding/bin">
 		</dir>
 	</classpath>
 

--- a/org.eclipse.richbeans.examples/src/rebel.xml
+++ b/org.eclipse.richbeans.examples/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/richbeans.git/org.eclipse.richbeans.examples/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/richbeans.git/org.eclipse.richbeans.examples/bin">
 		</dir>
 	</classpath>
 

--- a/org.eclipse.richbeans.widgets.file/src/rebel.xml
+++ b/org.eclipse.richbeans.widgets.file/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/richbeans.git/org.eclipse.richbeans.widgets.file/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/richbeans.git/org.eclipse.richbeans.widgets.file/bin">
 		</dir>
 	</classpath>
 

--- a/org.eclipse.richbeans.widgets/src/rebel.xml
+++ b/org.eclipse.richbeans.widgets/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/richbeans.git/org.eclipse.richbeans.widgets/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/richbeans.git/org.eclipse.richbeans.widgets/bin">
 		</dir>
 	</classpath>
 

--- a/org.eclipse.richbeans.xml/src/rebel.xml
+++ b/org.eclipse.richbeans.xml/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/richbeans.git/org.eclipse.richbeans.xml/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/richbeans.git/org.eclipse.richbeans.xml/bin">
 		</dir>
 	</classpath>
 


### PR DESCRIPTION
Ref: https://github.com/eclipse/richbeans/issues/109

The JRebel plugin assumes you will have a forward slash after the
expanded version of ${rebel.workspace.path} so you have to do it this
way

Change-Id: I6449e5068df73498462c303a1634b56627f183d6
Signed-off-by: Keith Ralphs <keith.ralphs@diamond.ac.uk>