### PR TITLE
[DAQ-841] Improvements to usability of ControlTreeViewer

### DIFF
--- a/org.eclipse.richbeans.widgets/src/org/eclipse/richbeans/widgets/cell/CComboWithEntryCellEditor.java
+++ b/org.eclipse.richbeans.widgets/src/org/eclipse/richbeans/widgets/cell/CComboWithEntryCellEditor.java
@@ -44,7 +44,7 @@ public class CComboWithEntryCellEditor extends CComboCellEditor {
 	 * @see CellEditor#dispose
 	 */
 	public CComboWithEntryCellEditor() {
-		setStyle(defaultStyle);
+		setStyle(DEFAULT_STYLE);
 	}
 
 	/**
@@ -59,7 +59,7 @@ public class CComboWithEntryCellEditor extends CComboCellEditor {
 	 *            the list of strings for the combo box
 	 */
 	public CComboWithEntryCellEditor(Composite parent, String[] items) {
-		this(parent, items, defaultStyle);
+		this(parent, items, DEFAULT_STYLE);
 	}
 
 	/**


### PR DESCRIPTION
The principal change it to modify CComboCellEditor so that you can
type a few letters of the scannable name you wish to add and
the combo box will go to the appropriate place in the list.

There are also a number of more cosmetic changes:
- Reduce visibility of class variables where possible
- Change constant name to conform to standard.
- Implement key release actions in keyReleased event (instead of
keyPressed)
- Removed activate(), as it did nothing.
- Added @Override where appropriate
- Simplified syntax by removing unnecessary boxing of values.

Signed-off-by: Anthony Hull <anthony.hull@diamond.ac.uk>