### PR TITLE
Remove environments that we are not interested in

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,11 +67,6 @@
 						<ws>gtk</ws>
 						<arch>x86_64</arch>
 					</environment>
-					<environment>
-						<os>win32</os>
-						<ws>win32</ws>
-						<arch>x86_64</arch>
-					</environment>
 				</environments>
 				<target>
 					<artifact>
@@ -112,7 +107,5 @@
       </plugins>
    </build>
    
-    
+
  </project>
-	
-	


### PR DESCRIPTION
If present, scanning tests can get the wrong SWT architecture, and fail

Signed-off-by: Matthew Webber <matthew.webber@diamond.ac.uk>