### PR TITLE
[I18-117] Add a case to NumberBox.getNumericValue(String)

### DIFF
--- a/org.eclipse.richbeans.widgets/src/org/eclipse/richbeans/widgets/scalebox/NumberBox.java
+++ b/org.eclipse.richbeans.widgets/src/org/eclipse/richbeans/widgets/scalebox/NumberBox.java
@@ -651,6 +651,11 @@ public abstract class NumberBox extends ButtonComposite implements BoundsProvide
 				}
 			}
 		}
+		try {
+			return Double.valueOf(txt);
+		} catch (java.lang.NumberFormatException ne) {
+			// Fall through.
+		}
 		return Double.NaN;
 	}
 


### PR DESCRIPTION
This fixes a bug where a listener was not fired when scientific notation
was entered into a NumberBox.

Signed-off-by: James Mudd <james.mudd@diamond.ac.uk>